### PR TITLE
Fix designability of UIView shadows

### DIFF
--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@IBDesignable
 public extension UIView {
 
     // MARK: - Corner radius


### PR DESCRIPTION
The properties were inspectable and could be written to, but in interface builder the shadow and corner radius was not properly shown.