### PR TITLE
Add stopUsingKeyboard to Keyboardable protocol

### DIFF
--- a/Sources/Protocols/Keyboardable.swift
+++ b/Sources/Protocols/Keyboardable.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public protocol Keyboardable: class {
-    var keyboardObserver: [Any] { get set }
+    var keyboardObservers: [Any] { get set }
     func keyboardChanges(height: CGFloat)
 }
 
@@ -30,7 +30,7 @@ public extension Keyboardable {
             self?.keyboardChanges(height: 0)
         }
 
-        keyboardObserver = [
+        keyboardObservers = [
             center.addObserver(forName: .UIKeyboardWillChangeFrame, object: nil, queue: nil, using: keyboardChangeFrameBlock),
             center.addObserver(forName: .UIKeyboardWillHide, object: nil, queue: nil, using: keyboardWillHideBlock)
         ]
@@ -39,6 +39,6 @@ public extension Keyboardable {
 
     func stopUsingKeyboard() {
         let center = NotificationCenter.default
-        keyboardObserver.forEach { center.removeObserver($0) }
+        keyboardObservers.forEach { center.removeObserver($0) }
     }
 }


### PR DESCRIPTION
`stopUsingKeyboard` has to be called before dismissing screen otherwise observers will remain active.

It also fixes problem deinit of object that uses this protocol. It was caused by registering observer with function instead of a block with `[weak self]`.
