### PR TITLE
Simplify sourceViewController on ModalCoordinator

### DIFF
--- a/Sources/Architecture/Coordinator.swift
+++ b/Sources/Architecture/Coordinator.swift
@@ -43,7 +43,7 @@ public protocol PushCoordinator: DefaultCoordinator {
 
 public protocol ModalCoordinator: DefaultCoordinator {
     var configuration: ((ViewController) -> Void)? { get }
-    var navigationController: UINavigationController { get }
+    var sourceViewController: UIViewController { get }
     weak var destinationNavigationController: UINavigationController? { get }
 }
 
@@ -100,10 +100,10 @@ public extension ModalCoordinator where ViewController: UIViewController, ViewCo
 
         if let destinationNavigationController = destinationNavigationController {
             // wrapper navigation controller given, present it
-            navigationController.present(destinationNavigationController, animated: animated, completion: nil)
+            sourceViewController.present(destinationNavigationController, animated: animated, completion: nil)
         } else {
             // no wrapper navigation controller given, present actual controller
-            navigationController.present(viewController, animated: animated, completion: nil)
+            sourceViewController.present(viewController, animated: animated, completion: nil)
         }
     }
 

--- a/Sources/Architecture/Coordinator.swift
+++ b/Sources/Architecture/Coordinator.swift
@@ -150,7 +150,7 @@ public extension PushModalCoordinator where ViewController: UIViewController, Vi
                 self.delegate?.didStop(in: self)
             }
         case .push:
-            let _ = navigationController?.popViewController(animated: animated)
+            _ = navigationController?.popViewController(animated: animated)
             delegate?.didStop(in: self)
         }
     }

--- a/Sources/AutoLayout/HairlineLayoutConstraint.swift
+++ b/Sources/AutoLayout/HairlineLayoutConstraint.swift
@@ -13,7 +13,7 @@ public class HairlineLayoutConstraint: NSLayoutConstraint {
 
     override public func awakeFromNib() {
         super.awakeFromNib()
-        self.constant = self.constant / UIScreen.main.scale
+        self.constant /= UIScreen.main.scale
     }
 
 }


### PR DESCRIPTION
Rename `navigationController` to `sourceViewController` on `ModalCoordinator` so it can be used on plain, non-Navigation View Controllers too. The property name should now also be more descriptive and prevent confusions.


Also fixes two minor issues required by SwiftLint.