### PR TITLE
Add error handling mechanisms

### DIFF
--- a/FuntastyKit.xcodeproj/project.pbxproj
+++ b/FuntastyKit.xcodeproj/project.pbxproj
@@ -15,6 +15,18 @@
 		52D6DA261BF00118002C0205 /* FuntastyKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9961BEFF375002C0205 /* FuntastyKit.swift */; };
 		B91C3C311E0967D2005336D2 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91C3C301E0967D2005336D2 /* UITableView+Extensions.swift */; };
 		B91C3C331E09682D005336D2 /* StoryboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91C3C321E09682D005336D2 /* StoryboardType.swift */; };
+		D09AACC51ED8683200438527 /* AlertCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC21ED8683200438527 /* AlertCoordinator.swift */; };
+		D09AACC61ED8683200438527 /* AlertCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC21ED8683200438527 /* AlertCoordinator.swift */; };
+		D09AACC71ED8683200438527 /* AlertCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC21ED8683200438527 /* AlertCoordinator.swift */; };
+		D09AACC81ED8683200438527 /* AlertCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC21ED8683200438527 /* AlertCoordinator.swift */; };
+		D09AACC91ED8683200438527 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC31ED8683200438527 /* Errors.swift */; };
+		D09AACCA1ED8683200438527 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC31ED8683200438527 /* Errors.swift */; };
+		D09AACCB1ED8683200438527 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC31ED8683200438527 /* Errors.swift */; };
+		D09AACCC1ED8683200438527 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC31ED8683200438527 /* Errors.swift */; };
+		D09AACCD1ED8683200438527 /* UIAlertController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC41ED8683200438527 /* UIAlertController+Error.swift */; };
+		D09AACCE1ED8683200438527 /* UIAlertController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC41ED8683200438527 /* UIAlertController+Error.swift */; };
+		D09AACCF1ED8683200438527 /* UIAlertController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC41ED8683200438527 /* UIAlertController+Error.swift */; };
+		D09AACD01ED8683200438527 /* UIAlertController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AACC41ED8683200438527 /* UIAlertController+Error.swift */; };
 		D0C9B6691E07295400EA3376 /* HairlineLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C9B6681E07295400EA3376 /* HairlineLayoutConstraint.swift */; };
 		D0C9B6811E072A6200EA3376 /* UIViewController+Deselection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C9B67F1E072A6200EA3376 /* UIViewController+Deselection.swift */; };
 		D0C9B6821E072A6200EA3376 /* UIWindow+RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C9B6801E072A6200EA3376 /* UIWindow+RootViewController.swift */; };
@@ -68,6 +80,9 @@
 		AD2FAA281CD0B6E100659CF4 /* FuntastyKitTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = FuntastyKitTests.plist; sourceTree = "<group>"; };
 		B91C3C301E0967D2005336D2 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UITableView+Extensions.swift"; path = "Sources/Extensions/UITableView+Extensions.swift"; sourceTree = "<group>"; };
 		B91C3C321E09682D005336D2 /* StoryboardType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoryboardType.swift; path = Sources/Protocols/StoryboardType.swift; sourceTree = "<group>"; };
+		D09AACC21ED8683200438527 /* AlertCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AlertCoordinator.swift; path = Sources/Errors/AlertCoordinator.swift; sourceTree = "<group>"; };
+		D09AACC31ED8683200438527 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Errors/Errors.swift; sourceTree = "<group>"; };
+		D09AACC41ED8683200438527 /* UIAlertController+Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIAlertController+Error.swift"; path = "Sources/Errors/UIAlertController+Error.swift"; sourceTree = "<group>"; };
 		D0C9B6681E07295400EA3376 /* HairlineLayoutConstraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HairlineLayoutConstraint.swift; path = Sources/AutoLayout/HairlineLayoutConstraint.swift; sourceTree = "<group>"; };
 		D0C9B67F1E072A6200EA3376 /* UIViewController+Deselection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+Deselection.swift"; path = "Sources/Extensions/UIViewController+Deselection.swift"; sourceTree = "<group>"; };
 		D0C9B6801E072A6200EA3376 /* UIWindow+RootViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIWindow+RootViewController.swift"; path = "Sources/Extensions/UIWindow+RootViewController.swift"; sourceTree = "<group>"; };
@@ -143,6 +158,7 @@
 				D0C9B68D1E07369C00EA3376 /* Architecture */,
 				D0C9B67E1E072A5600EA3376 /* Extensions */,
 				D0C9B6651E07249C00EA3376 /* Protocols */,
+				D09AACC11ED8681900438527 /* Errors */,
 				D0EC60511E07229800D3E4D8 /* AutoLayout */,
 				52D6D9971BEFF375002C0205 /* FuntastyKitTests.swift */,
 				52D6D99C1BEFF38C002C0205 /* Configs */,
@@ -171,6 +187,16 @@
 				DD7502731C68FC20006590AF /* Tests */,
 			);
 			path = Configs;
+			sourceTree = "<group>";
+		};
+		D09AACC11ED8681900438527 /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				D09AACC21ED8683200438527 /* AlertCoordinator.swift */,
+				D09AACC31ED8683200438527 /* Errors.swift */,
+				D09AACC41ED8683200438527 /* UIAlertController+Error.swift */,
+			);
+			name = Errors;
 			sourceTree = "<group>";
 		};
 		D0C9B6651E07249C00EA3376 /* Protocols */ = {
@@ -571,14 +597,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0D5D4481E07EFAF004889D6 /* Coordinator.swift in Sources */,
+				D09AACC51ED8683200438527 /* AlertCoordinator.swift in Sources */,
 				B91C3C331E09682D005336D2 /* StoryboardType.swift in Sources */,
 				D0C9B6821E072A6200EA3376 /* UIWindow+RootViewController.swift in Sources */,
 				D0C9B6861E072F2D00EA3376 /* Nibable.swift in Sources */,
 				D0D5D44E1E07F015004889D6 /* UIView+Extensions.swift in Sources */,
 				52D6D9981BEFF375002C0205 /* FuntastyKit.swift in Sources */,
+				D09AACC91ED8683200438527 /* Errors.swift in Sources */,
 				B91C3C311E0967D2005336D2 /* UITableView+Extensions.swift in Sources */,
 				D0C9B6851E072F2D00EA3376 /* Keyboardable.swift in Sources */,
 				D0C9B6691E07295400EA3376 /* HairlineLayoutConstraint.swift in Sources */,
+				D09AACCD1ED8683200438527 /* UIAlertController+Error.swift in Sources */,
 				D0C9B6811E072A6200EA3376 /* UIViewController+Deselection.swift in Sources */,
 				D0D5D4491E07EFAF004889D6 /* ServiceHolder.swift in Sources */,
 			);
@@ -596,7 +625,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D09AACCB1ED8683200438527 /* Errors.swift in Sources */,
 				52D6D9EA1BEFFFA4002C0205 /* FuntastyKit.swift in Sources */,
+				D09AACC71ED8683200438527 /* AlertCoordinator.swift in Sources */,
+				D09AACCF1ED8683200438527 /* UIAlertController+Error.swift in Sources */,
 				D0D5D44A1E07EFB1004889D6 /* ServiceHolder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -605,7 +637,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D09AACCC1ED8683200438527 /* Errors.swift in Sources */,
 				52D6DA091BF00081002C0205 /* FuntastyKit.swift in Sources */,
+				D09AACC81ED8683200438527 /* AlertCoordinator.swift in Sources */,
+				D09AACD01ED8683200438527 /* UIAlertController+Error.swift in Sources */,
 				D0D5D44C1E07EFB2004889D6 /* ServiceHolder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -614,7 +649,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D09AACCA1ED8683200438527 /* Errors.swift in Sources */,
 				52D6DA261BF00118002C0205 /* FuntastyKit.swift in Sources */,
+				D09AACC61ED8683200438527 /* AlertCoordinator.swift in Sources */,
+				D09AACCE1ED8683200438527 /* UIAlertController+Error.swift in Sources */,
 				D0D5D44B1E07EFB1004889D6 /* ServiceHolder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Errors/AlertCoordinator.swift
+++ b/Sources/Errors/AlertCoordinator.swift
@@ -34,8 +34,8 @@ public final class AlertCoordinator {
     }
 }
 
-extension DefaultCoordinator {
-    func navigateToAlert(for error: Error) {
+public extension DefaultCoordinator {
+    public func navigateToAlert(for error: Error) {
         guard let viewController = self.viewController else {
             return
         }
@@ -43,7 +43,7 @@ extension DefaultCoordinator {
         alertCoordinator.start()
     }
 
-    func navigateToAlert(title: String, message: String) {
+    public func navigateToAlert(title: String, message: String) {
         guard let viewController = self.viewController else {
             return
         }
@@ -51,7 +51,7 @@ extension DefaultCoordinator {
         alertCoordinator.start()
     }
 
-    func navigateToAlert(title: String, message: String, actions: [UIAlertAction]?) {
+    public func navigateToAlert(title: String, message: String, actions: [UIAlertAction]?) {
         guard let viewController = self.viewController else {
             return
         }
@@ -61,7 +61,7 @@ extension DefaultCoordinator {
 }
 
 public extension AlertCoordinator {
-    func start() {
+    public func start() {
         var alert = UIAlertController()
         if let error = error {
             alert = UIAlertController(error: error)
@@ -73,7 +73,7 @@ public extension AlertCoordinator {
         viewController = alert
     }
 
-    func stop() {
+    public func stop() {
         viewController?.dismiss(animated: true, completion: nil)
     }
 }

--- a/Sources/Errors/AlertCoordinator.swift
+++ b/Sources/Errors/AlertCoordinator.swift
@@ -1,0 +1,79 @@
+//
+//  AlertCoordinator.swift
+//  FuntastyKit
+//
+//  Created by Milan Strnad on 03/03/17.
+//  Copyright © 2017 The Funtasty s.r.o. All rights reserved.
+//
+
+import UIKit
+
+public final class AlertCoordinator {
+
+    let parentViewController: UIViewController
+    weak var viewController: UIAlertController?
+
+    var error: Error?
+
+    var title: String?
+    var message: String?
+    var actions: [UIAlertAction]?
+
+    // MARK: - Inits
+
+    public init(parent: UIViewController, error: Error) {
+        self.parentViewController = parent
+        self.error = error
+    }
+
+    public init(parent: UIViewController, title: String?, message: String?, actions: [UIAlertAction]? = [UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default)]) {
+        self.parentViewController = parent
+        self.title = title
+        self.message = message
+        self.actions = actions
+    }
+}
+
+extension DefaultCoordinator {
+    func navigateToAlert(for error: Error) {
+        guard let viewController = self.viewController else {
+            return
+        }
+        let alertCoordinator = AlertCoordinator(parent: viewController, error: error)
+        alertCoordinator.start()
+    }
+
+    func navigateToAlert(title: String, message: String) {
+        guard let viewController = self.viewController else {
+            return
+        }
+        let alertCoordinator = AlertCoordinator(parent: viewController, title: title, message: message)
+        alertCoordinator.start()
+    }
+
+    func navigateToAlert(title: String, message: String, actions: [UIAlertAction]?) {
+        guard let viewController = self.viewController else {
+            return
+        }
+        let alertCoordinator = AlertCoordinator(parent: viewController, title: title, message: message, actions: actions)
+        alertCoordinator.start()
+    }
+}
+
+public extension AlertCoordinator {
+    func start() {
+        var alert = UIAlertController()
+        if let error = error {
+            alert = UIAlertController(error: error)
+        } else {
+            alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            actions?.forEach(alert.addAction)
+        }
+        parentViewController.present(alert, animated: true, completion: nil)
+        viewController = alert
+    }
+
+    func stop() {
+        viewController?.dismiss(animated: true, completion: nil)
+    }
+}

--- a/Sources/Errors/AlertCoordinator.swift
+++ b/Sources/Errors/AlertCoordinator.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-public final class AlertCoordinator {
+public class AlertCoordinator: DefaultCoordinator {
 
     let parentViewController: UIViewController
-    weak var viewController: UIAlertController?
+    public weak var viewController: UIAlertController?
 
     var error: Error?
 

--- a/Sources/Errors/AlertCoordinator.swift
+++ b/Sources/Errors/AlertCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 public class AlertCoordinator: DefaultCoordinator {
     enum InputType {
         case error(Error)
-        case custom(title: String, message: String?, actions: [UIAlertAction]?)
+        case custom(title: String, message: String?, actions: [ErrorAction]?)
 
         func alertController() -> UIAlertController {
             switch self {
@@ -19,7 +19,7 @@ public class AlertCoordinator: DefaultCoordinator {
                 return UIAlertController(error: error)
             case .custom(let title, let message, let actions):
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-                actions?.forEach(alert.addAction)
+                actions?.map { $0.alertAction() }.forEach(alert.addAction)
                 return alert
             }
         }
@@ -37,7 +37,7 @@ public class AlertCoordinator: DefaultCoordinator {
         self.type = .error(error)
     }
 
-    public init(parent: UIViewController, title: String, message: String?, actions: [UIAlertAction] = [UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default)]) {
+    public init(parent: UIViewController, title: String, message: String?, actions: [ErrorAction] = [ErrorAction(title: NSLocalizedString("OK", comment: "OK"))]) {
         self.parentViewController = parent
         self.type = .custom(title: title, message: message, actions: actions)
     }
@@ -55,6 +55,23 @@ public class AlertCoordinator: DefaultCoordinator {
     }
 }
 
+public extension ErrorAction {
+    func alertStyle() -> UIAlertActionStyle {
+        switch self.style {
+        case .default:
+            return .default
+        case .cancel:
+            return .cancel
+        case .destructive:
+            return .destructive
+        }
+    }
+
+    func alertAction() -> UIAlertAction {
+        return UIAlertAction(title: self.title, style: self.alertStyle(), handler: { _ in self.action?() })
+    }
+}
+
 public extension DefaultCoordinator {
     public func showAlert(for error: Error) {
         guard let viewController = self.viewController else {
@@ -65,7 +82,7 @@ public extension DefaultCoordinator {
         alertCoordinator.start()
     }
 
-    public func showAlert(title: String, message: String, actions: [UIAlertAction]? = nil) {
+    public func showAlert(title: String, message: String, actions: [ErrorAction]? = nil) {
         guard let viewController = self.viewController else {
             return
         }

--- a/Sources/Errors/Errors.swift
+++ b/Sources/Errors/Errors.swift
@@ -13,13 +13,21 @@ public protocol ResolvableError: LocalizedError {
 }
 
 public struct ErrorAction {
+    public enum Style: Int {
+        case `default`
+        case cancel
+        case destructive
+    }
+
     public typealias ErrorHandler = () -> Void
 
     let title: String
     var action: ErrorHandler?
+    var style: Style
 
-    public init(title: String, action: ErrorHandler? = nil) {
+    public init(title: String, style: Style = .default, action: ErrorHandler? = nil) {
         self.title = title
+        self.style = style
         self.action = action
     }
 }

--- a/Sources/Errors/Errors.swift
+++ b/Sources/Errors/Errors.swift
@@ -1,0 +1,25 @@
+//
+//  Errors.swift
+//  FuntastyKit
+//
+//  Created by Milan Strnad on 03/03/17.
+//  Copyright © 2017 The Funtasty s.r.o. All rights reserved.
+//
+
+import Foundation
+
+public protocol ResolvableError: LocalizedError {
+    var actions: [ErrorAction] { get }
+}
+
+public struct ErrorAction {
+    public typealias ErrorHandler = () -> Void
+
+    let title: String
+    var action: ErrorHandler?
+
+    public init(title: String, action: ErrorHandler? = nil) {
+        self.title = title
+        self.action = action
+    }
+}

--- a/Sources/Errors/UIAlertController+Error.swift
+++ b/Sources/Errors/UIAlertController+Error.swift
@@ -1,0 +1,33 @@
+//
+//  UIAlertController+Error.swift
+//  FuntastyKit
+//
+//  Created by Milan Strnad on 03/03/17.
+//  Copyright © 2017 The Funtasty s.r.o. All rights reserved.
+//
+
+import UIKit
+
+public extension UIAlertController {
+    convenience init(error: Error) {
+        switch error {
+        case let error as ResolvableError:
+            self.init(title: error.errorDescription ?? NSLocalizedString("Error", comment: "Error"), message: error.failureReason ?? error.localizedDescription, preferredStyle: .alert)
+            error.actions.forEach { errorAction in
+                let action = UIAlertAction(title: errorAction.title, style: .default, handler: { _ in
+                    errorAction.action?()
+                })
+                self.addAction(action)
+            }
+            if error.actions.isEmpty {
+                self.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default))
+            }
+        case let error as LocalizedError:
+            self.init(title: error.errorDescription ?? NSLocalizedString("Error", comment: "Error"), message: error.failureReason ?? error.localizedDescription, preferredStyle: .alert)
+            self.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default))
+        default:
+            self.init(title: NSLocalizedString("Error", comment: "Error"), message: error.localizedDescription, preferredStyle: .alert)
+            self.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default))
+        }
+    }
+}

--- a/Sources/Errors/UIAlertController+Error.swift
+++ b/Sources/Errors/UIAlertController+Error.swift
@@ -13,12 +13,7 @@ public extension UIAlertController {
         switch error {
         case let error as ResolvableError:
             self.init(title: error.errorDescription ?? NSLocalizedString("Error", comment: "Error"), message: error.failureReason ?? error.localizedDescription, preferredStyle: .alert)
-            error.actions.forEach { errorAction in
-                let action = UIAlertAction(title: errorAction.title, style: .default, handler: { _ in
-                    errorAction.action?()
-                })
-                self.addAction(action)
-            }
+            error.actions.map { $0.alertAction() }.forEach(self.addAction)
             if error.actions.isEmpty {
                 self.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: .default))
             }


### PR DESCRIPTION
This PR adds error handling mechanisms as used on CarPics project.

It introduces a protocol `ResolableError` to implement custom recoverable errors. It also provides a convenience init on `UIAlertController` for an Error type, including `ResolvableError` and `LocalizedError`. Finally, an `AlertCoordinator` is added to simplify UIAlertController presentation.