### PR TITLE
Remove where clause from Coordinated

### DIFF
--- a/Sources/Architecture/Coordinator.swift
+++ b/Sources/Architecture/Coordinator.swift
@@ -162,7 +162,7 @@ public protocol CoordinatorDelegate: class {
 }
 
 /// Used typically on view controllers to refer to it's coordinator
-public protocol Coordinated: class where Self: UIViewController {
+public protocol Coordinated: class {
     associatedtype C: Coordinator
     var coordinator: C! { get set }
     func getCoordinator() -> Coordinator?


### PR DESCRIPTION
This fixes compilation error in Swift 3.1, but keep in mind that we can introduce it back later since it works in Swift 3.2 a newer.