### PR TITLE
Rename configure method parameter name

### DIFF
--- a/Sources/Architecture/Coordinator.swift
+++ b/Sources/Architecture/Coordinator.swift
@@ -32,12 +32,12 @@ public protocol DefaultCoordinator: Coordinator {
 }
 
 public protocol PushCoordinator: DefaultCoordinator {
-    func configure(controller: ViewController)
+    func configure(viewController: ViewController)
     var navigationController: UINavigationController { get }
 }
 
 public protocol ModalCoordinator: DefaultCoordinator {
-    func configure(controller: ViewController)
+    func configure(viewController: ViewController)
     var sourceViewController: UIViewController { get }
     weak var destinationNavigationController: UINavigationController? { get }
 }
@@ -72,7 +72,7 @@ public extension PushCoordinator {
             return
         }
 
-        configure(controller: viewController)
+        configure(viewController: viewController)
         navigationController.pushViewController(viewController, animated: animated)
     }
 
@@ -89,7 +89,7 @@ public extension ModalCoordinator {
             return
         }
 
-        configure(controller: viewController)
+        configure(viewController: viewController)
 
         if let destinationNavigationController = destinationNavigationController {
             // wrapper navigation controller given, present it

--- a/Tests/FuntastyKitTests/ExampleScene.swift
+++ b/Tests/FuntastyKitTests/ExampleScene.swift
@@ -72,9 +72,9 @@ final class ExampleCoordinator: ModalCoordinator {
         self.serviceHolder = serviceHolder
     }
 
-    func configure(controller: ExampleViewController) {
-        let viewModel = ExampleViewModel(model: model, coordinator: self, viewController: controller, service: serviceHolder.get())
-        controller.viewModel = viewModel
+    func configure(viewController: ExampleViewController) {
+        let viewModel = ExampleViewModel(model: model, coordinator: self, viewController: viewController, service: serviceHolder.get())
+        viewController.viewModel = viewModel
     }
 }
 


### PR DESCRIPTION
Rename `controller` parameter to `viewController` to make it consistent with naming of other methods.