### PR TITLE
Fix compilation of AlertCoordinator in Swift 4.0

### DIFF
--- a/FuntastyKit.podspec
+++ b/FuntastyKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "FuntastyKit"
-  s.version = "1.1.1"
+  s.version = "1.1.2"
   s.summary = "A collection of Swift utilities and protocols used in our projects."
   s.description = <<-DESC
      A collection of Swift utilities and protocols used in our projects.

--- a/Sources/Errors/AlertCoordinator.swift
+++ b/Sources/Errors/AlertCoordinator.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 public class AlertCoordinator: DefaultCoordinator {
+    public typealias ViewController = UIAlertController
 
     public enum Source {
         case button(UIBarButtonItem)


### PR DESCRIPTION
The latest version can be compiled only in Xcode 9.3 or Swift 4.1 respectively, but it can be backwards compatible with Swift 4.0.