### PR TITLE
Fix crashing IB agent

### DIFF
--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -18,7 +18,9 @@ public extension UIView {
             return layer.cornerRadius
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.cornerRadius = newValue
+            #endif
         }
     }
 
@@ -29,7 +31,9 @@ public extension UIView {
             return layer.shadowColor.flatMap(UIColor.init)
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.shadowColor = newValue?.cgColor
+            #endif
         }
     }
 
@@ -38,7 +42,9 @@ public extension UIView {
             return layer.shadowOffset
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.shadowOffset = newValue
+            #endif
         }
     }
 
@@ -47,7 +53,9 @@ public extension UIView {
             return layer.shadowRadius
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.shadowRadius = newValue
+            #endif
         }
     }
 
@@ -56,7 +64,9 @@ public extension UIView {
             return layer.shadowOpacity
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.shadowOpacity = newValue
+            #endif
         }
     }
 
@@ -67,7 +77,9 @@ public extension UIView {
             return layer.borderWidth
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.borderWidth = newValue
+            #endif
         }
     }
 
@@ -76,7 +88,9 @@ public extension UIView {
             return layer.borderColor.flatMap(UIColor.init)
         }
         set {
+            #if !TARGET_INTERFACE_BUILDER
             layer.borderColor = newValue?.cgColor
+            #endif
         }
     }
 }

--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 @IBDesignable
-public extension UIView {
+extension UIView {
 
     // MARK: - Corner radius
 
-    @IBInspectable var cornerRadius: CGFloat {
+    @IBInspectable open var cornerRadius: CGFloat {
         get {
             return layer.cornerRadius
         }
@@ -26,7 +26,7 @@ public extension UIView {
 
     // MARK: - Shadow
 
-    @IBInspectable var shadowColor: UIColor? {
+    @IBInspectable open var shadowColor: UIColor? {
         get {
             return layer.shadowColor.flatMap(UIColor.init)
         }
@@ -37,7 +37,7 @@ public extension UIView {
         }
     }
 
-    @IBInspectable var shadowOffset: CGSize {
+    @IBInspectable open var shadowOffset: CGSize {
         get {
             return layer.shadowOffset
         }
@@ -48,7 +48,7 @@ public extension UIView {
         }
     }
 
-    @IBInspectable var shadowRadius: CGFloat {
+    @IBInspectable open var shadowRadius: CGFloat {
         get {
             return layer.shadowRadius
         }
@@ -59,7 +59,7 @@ public extension UIView {
         }
     }
 
-    @IBInspectable var shadowOpacity: Float {
+    @IBInspectable open var shadowOpacity: Float {
         get {
             return layer.shadowOpacity
         }
@@ -72,7 +72,7 @@ public extension UIView {
 
     // MARK: - Border
 
-    @IBInspectable var borderWidth: CGFloat {
+    @IBInspectable open var borderWidth: CGFloat {
         get {
             return layer.borderWidth
         }
@@ -83,7 +83,7 @@ public extension UIView {
         }
     }
 
-    @IBInspectable var borderColor: UIColor? {
+    @IBInspectable open var borderColor: UIColor? {
         get {
             return layer.borderColor.flatMap(UIColor.init)
         }


### PR DESCRIPTION
This fix should reduce some amount of IB crashes. Worked for me. 

If we would like to have IB previews of designs, my theory is, we would need to override draw(_ rect:).