### PR TITLE
Add animation option to animate rootViewController in UIWindow

### DIFF
--- a/Sources/Extensions/UIWindow+RootViewController.swift
+++ b/Sources/Extensions/UIWindow+RootViewController.swift
@@ -21,7 +21,7 @@ public extension UIWindow {
      - parameter completion:     Completion block to be invoked after the transition finishes
      */
     @nonobjc
-    func setRootViewController(_ viewController: UIViewController, animated: Bool, duration: TimeInterval = 0.3, options: UIView.AnimationOptions = [.transitionCrossDissolve], completion: ((Bool) -> Void)? = nil) {
+    func setRootViewController(_ viewController: UIViewController, animated: Bool, duration: TimeInterval = 0.3, options: UIView.AnimationOptions = .transitionCrossDissolve, completion: ((Bool) -> Void)? = nil) {
         if animated {
             UIView.transition(with: self, duration: duration, options: options, animations: {
                 self.rootViewController = viewController

--- a/Sources/Extensions/UIWindow+RootViewController.swift
+++ b/Sources/Extensions/UIWindow+RootViewController.swift
@@ -21,15 +21,10 @@ public extension UIWindow {
      - parameter completion:     Completion block to be invoked after the transition finishes
      */
     @nonobjc
-    func setRootViewController(_ viewController: UIViewController, animated: Bool, duration: TimeInterval = 0.3, completion: ((Bool) -> Void)? = nil) {
+    func setRootViewController(_ viewController: UIViewController, animated: Bool, duration: TimeInterval = 0.3, options: UIView.AnimationOptions = [.transitionCrossDissolve], completion: ((Bool) -> Void)? = nil) {
         if animated {
-            UIView.transition(with: self, duration: duration, options: .transitionCrossDissolve, animations: {
-                let oldState = UIView.areAnimationsEnabled
-                UIView.setAnimationsEnabled(false)
-
+            UIView.transition(with: self, duration: duration, options: options, animations: {
                 self.rootViewController = viewController
-
-                UIView.setAnimationsEnabled(oldState)
             }, completion: completion)
         } else {
             self.rootViewController = viewController


### PR DESCRIPTION
Add option to animate set of rootViewController in UIWindow. Previous implementation disabled animations when settings rootViewController and haven't support for animation type. 