### PR TITLE
Add default destination controller

### DIFF
--- a/Sources/FuntastyKit/Architecture/Coordinator.swift
+++ b/Sources/FuntastyKit/Architecture/Coordinator.swift
@@ -106,6 +106,8 @@ public extension PushCoordinator {
 }
 
 public extension ModalCoordinator {
+    var destinationNavigationController: UINavigationController? { nil }
+
     func start() {
         guard let viewController = viewController else {
             return
@@ -131,6 +133,8 @@ public extension ModalCoordinator {
 }
 
 public extension TabBarItemCoordinator {
+    var destinationNavigationController: UINavigationController? { nil }
+
     func start() {
         guard let viewController = viewController else {
             return


### PR DESCRIPTION
In case you do not need navigation controller in the modal, `ModalCoordinator` still requires its definition. I believe we don't need it. Templates always generate navigation controllers, but there could be many reasons to remove them.

```swift
final class SomeCoordinator: ModalCoordinator {
    let sourceViewController: UIViewController
    weak var viewController:SomeViewController?

    // Required by modal coordinator protocol
    let destinationNavigationController: UINavigationController? = nil

    private let serviceHolder: ServiceHolder

    init(sourceViewController: UIViewController, serviceHolder: ServiceHolder) {
        self.sourceViewController = sourceViewController
        self.serviceHolder = serviceHolder
        self.viewController = SomeStoryboard.viewController.instantiate()
    }
```