### PR TITLE
Remove SwiftLint installation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint
       run: |
-        brew install swiftlint
         swiftlint --strict
     - name: Pod lib lint
       run: |


### PR DESCRIPTION
SwiftLint is preinstalled on CI machines.